### PR TITLE
feat: ✨ use regular expressions when matching woooo

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,11 @@
 import os
+import re
 import random
 from discord.ext import commands
 import discord
 
 client = commands.Bot(command_prefix=['cum '])
+woo_regex = re.compile(r"woo+\b", flags=re.IGNORECASE)
 
 @client.event
 async def on_ready():
@@ -13,7 +15,7 @@ async def on_ready():
 async def on_message(msg):
    if msg.author == client.user:
       return
-   if "woo" in msg.content.lower():
+   if woo_regex.search(msg.content) is not None:
       await msg.channel.send("https://tenor.com/view/pop-smoke-dance-nyc-dance-move-smile-gif-16391422")
    if "among us" in msg.content.lower() or "amogus" in msg.content.lower():
       await msg.channel.send('among us')


### PR DESCRIPTION
This commit introduces the use of regular expressions for matching woo.
The regular expression used is `woo+\b`.
This means that the regular expression will match `woo`, `wooooo`, `woooooooo`, but not `woof`, 'wooops' or `wo`.

For the gif to be sent, a message has to have at least one match.
| Message content | Will GIF be sent? |
| ------------------- | :-----------------: |
woo | ✅ 
wo | ❌ 
it's wooo time | ✅ 
wooo wowowowo owowoooo | ✅ 
you came back from the woods | ❌ 
owoooooooooooo | ✅ 

As you can see, the last example is currently matched. If you want me to change that, let me know.