### PR TITLE
Added formatted help message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,8 +3,9 @@ import re
 import random
 from discord.ext import commands
 import discord
+from pretty_help import PrettyHelp
 
-client = commands.Bot(command_prefix=['cum '])
+client = commands.Bot(command_prefix=['cum '], help_command=PrettyHelp())
 woo_regex = re.compile(r"woo+\b", flags=re.IGNORECASE)
 
 @client.event

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 git+https://github.com/Rapptz/discord.py
+discord-pretty-help==1.1.2
+


### PR DESCRIPTION
With this pull request, when the user types `cum help`, instead of showing a bland code block, a nice formatted embed will apear showing the commands of the bot.